### PR TITLE
fix: remove invalid '*' from theme files

### DIFF
--- a/libs/ngx-owl-carousel-o/src/lib/styles/prebuilt-themes/owl.theme.default.css
+++ b/libs/ngx-owl-carousel-o/src/lib/styles/prebuilt-themes/owl.theme.default.css
@@ -36,7 +36,7 @@
   .owl-theme .owl-dots .owl-dot {
     display: inline-block;
     zoom: 1;
-    *display: inline; }
+    display: inline; }
     .owl-theme .owl-dots .owl-dot span {
       width: 10px;
       height: 10px;

--- a/libs/ngx-owl-carousel-o/src/lib/styles/prebuilt-themes/owl.theme.green.css
+++ b/libs/ngx-owl-carousel-o/src/lib/styles/prebuilt-themes/owl.theme.green.css
@@ -36,7 +36,7 @@
   .owl-theme .owl-dots .owl-dot {
     display: inline-block;
     zoom: 1;
-    *display: inline; }
+    display: inline; }
     .owl-theme .owl-dots .owl-dot span {
       width: 10px;
       height: 10px;

--- a/libs/ngx-owl-carousel-o/src/lib/styles/scss/_theme.scss
+++ b/libs/ngx-owl-carousel-o/src/lib/styles/scss/_theme.scss
@@ -40,7 +40,7 @@
 		.owl-dot {
 			display: inline-block;
 			zoom: 1;
-			*display: inline;
+			display: inline;
 
 			span {
 				width: $dot-width;

--- a/ngx-owl-carousel-o/lib/styles/prebuilt-themes/owl.theme.default.css
+++ b/ngx-owl-carousel-o/lib/styles/prebuilt-themes/owl.theme.default.css
@@ -36,7 +36,7 @@
   .owl-theme .owl-dots .owl-dot {
     display: inline-block;
     zoom: 1;
-    *display: inline; }
+    display: inline; }
     .owl-theme .owl-dots .owl-dot span {
       width: 10px;
       height: 10px;

--- a/ngx-owl-carousel-o/lib/styles/prebuilt-themes/owl.theme.green.css
+++ b/ngx-owl-carousel-o/lib/styles/prebuilt-themes/owl.theme.green.css
@@ -36,7 +36,7 @@
   .owl-theme .owl-dots .owl-dot {
     display: inline-block;
     zoom: 1;
-    *display: inline; }
+    display: inline; }
     .owl-theme .owl-dots .owl-dot span {
       width: 10px;
       height: 10px;

--- a/ngx-owl-carousel-o/lib/styles/scss/_theme.scss
+++ b/ngx-owl-carousel-o/lib/styles/scss/_theme.scss
@@ -40,7 +40,7 @@
 		.owl-dot {
 			display: inline-block;
 			zoom: 1;
-			*display: inline;
+			display: inline;
 
 			span {
 				width: $dot-width;


### PR DESCRIPTION
This PR should resolve issue https://github.com/vitalii-andriiovskyi/ngx-owl-carousel-o/issues/201