### PR TITLE
Update peerDependencies and bump to 20.0.1

### DIFF
--- a/ngx-owl-carousel-o/package.json
+++ b/ngx-owl-carousel-o/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../node_modules/ng-packagr/package.schema.json",
   "name": "ngx-owl-carousel-o",
-  "version": "20.0.0",
+  "version": "20.0.1",
   "description": "Angular powered owl-carousel",
   "keywords": [
     "angular",
@@ -24,8 +24,8 @@
     "url": "https://github.com/vitalii-andriiovskyi/ngx-owl-carousel-o/issues"
   },
   "peerDependencies": {
-    "@angular/common": " ^19.0.0-rc.0 || ^19.0.0",
-    "@angular/core": "^19.0.0-rc.0 || ^19.0.0",
+    "@angular/common": " ^20.0.0-rc.0 || ^20.0.0",
+    "@angular/core": "^20.0.0-rc.0 || ^20.0.0",
     "rxjs": "^6.0.1 || ^7.0.0"
   },
   "exports": {


### PR DESCRIPTION
The release for the 20.0.0 version of ngx-owl-carousel missed a proper update of the peerDependencies versions.

This commit updates `@angular/core` and `@angular/common` to the ^20.0.0-rc and ^20.0.0 of these packages.

I've bumped the package version to 20.0.1 to include these changes in a new release.